### PR TITLE
Fix Data Disk Initialization for Single Disk VMs

### DIFF
--- a/prepare_vm_disks.ps1
+++ b/prepare_vm_disks.ps1
@@ -26,7 +26,15 @@ $letters = 83..89 | ForEach-Object { [char]$_ }
 $count = 0
 $label = "datadisk"
 
-for($index = 2; $index -lt $disks.Count; $index++) {
+[Array]$initializedDisks = Get-Disk | where { $_.PartitionStyle -ne 'Raw' }
+
+if ($initializedDisks.Count -eq 1) {
+    $indexStart = 1
+} else {
+    $indexStart = 2
+}
+
+for ($index = $indexStart; $index -lt $disks.Count; $index++) {
     $driveLetter = $letters[$count].ToString()
     if ($disks[$index].partitionstyle -eq 'raw') {
         $disks[$index] | Initialize-Disk -PartitionStyle MBR -PassThru |

--- a/prepare_vm_disks.ps1
+++ b/prepare_vm_disks.ps1
@@ -1,5 +1,3 @@
-#!/bin/bash
-
 # The MIT License (MIT)
 #
 # Copyright (c) 2015 Microsoft Azure


### PR DESCRIPTION
## Purpose
<!-- Describe the intention of the changes being proposed. What problem does it solve or functionality does it add? -->
* Fixes initializing VM data disks when there is only 1 OS disk as part of the VM image.

## Does this introduce a breaking change?
<!-- Mark one with an "x". -->
```
[ ] Yes
[x] No
```

## Pull Request Type
What kind of change does this Pull Request introduce?

<!-- Please check the one that applies to this PR using "x". -->
```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Documentation content changes
[ ] Other... Please describe:
```

## How to Test
*  Get the code

```
git clone [repo-address]
cd [repo-name]
git checkout [branch-name]
npm install
```

* Test the code
<!-- Add steps to run the tests suite and/or manually test -->
```
```

## What to Check
Verify that the following are valid
* ...

## Other Information
<!-- Add any other helpful information that may be needed here. -->
When deploying a VMSS with the following vmSku and image reference, this script failed to initialize my disk as there is only the C: drive and no Temp D: drive.
```
    "type": "Microsoft.Compute/virtualMachineScaleSets",
      "apiVersion": "2020-12-01",
      "location": "westus",
      "dependsOn": [],
      "sku": {
        "name": "Standard_D4s_v4",
        "tier": "Standard",
        "capacity": "3"
      },
      "properties": {
        "virtualMachineProfile": {
          "priority": "Regular",
          "storageProfile": {
            "imageReference": {
              "publisher": "MicrosoftWindowsServer",
              "offer": "WindowsServer",
              "sku": "2019-Datacenter-with-Containers",
              "version": "latest"
           },
      }
}
```